### PR TITLE
Docs: Add CITATION.cff

### DIFF
--- a/CITATION.cff
+++ b/CITATION.cff
@@ -1,0 +1,22 @@
+cff-version: 1.2.0
+message: "If you use this lesson, please cite it as below."
+type: dataset
+title: "Research Community Outreach with Open Science Team Agreements"
+authors:
+  - family-names: Teplitzky
+    given-names: Samantha
+  - family-names: Deardorff
+    given-names: Ariel
+  - family-names: Wilairat
+    given-names: Samantha
+abstract: "Introduces the Open Science Team Agreement template as a practical tool for researchers and librarians to advocate for open science practices and plan research outreach activities."
+keywords:
+  - team agreements
+  - community
+  - open science
+  - outreach
+license: CC-BY-4.0
+version: 1.0.0
+date-released: 2025-12-23
+repository-code: "https://github.com/LibraryCarpentry/lc-team-agreements"
+url: "https://librarycarpentry.github.io/lc-team-agreements/"


### PR DESCRIPTION
This PR adds a CITATION.cff file to make the lesson citable, generated from the IMLS Open Science project metadata.